### PR TITLE
Set up asset pipeline

### DIFF
--- a/osmlab/__init__.py
+++ b/osmlab/__init__.py
@@ -1,5 +1,7 @@
 from flask import Flask
+from flask_assets import Environment, Bundle
 
 app = Flask(__name__)
 
+import osmlab.config.assets
 import osmlab.views

--- a/osmlab/config/assets.py
+++ b/osmlab/config/assets.py
@@ -1,0 +1,19 @@
+from osmlab import app
+from flask_assets import Environment, Bundle
+
+assets = Environment(app)
+
+# JavaScript asset bundle
+javascripts = Bundle('javascript/home/slideshow.js', filters='rjsmin', output='build/main-%(version)s.js')
+assets.register('javascripts', javascripts)
+
+# CSS asset bundle
+stylesheets = Bundle(
+  'css/global.css',
+  'css/layout.css',
+  'css/components/*.css',
+  'css/home/*.css',
+  'css/gallery/*.css',
+  output='build/main-%(version)s.css'
+)
+assets.register('stylesheets', stylesheets)

--- a/osmlab/templates/layout.html
+++ b/osmlab/templates/layout.html
@@ -14,18 +14,9 @@
 
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
 
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/global.css') }}">
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/layout.css') }}">
-
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/home/index.css') }}">
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/home/about.css') }}">
-
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/components/floating_arrow_link.css') }}">
-
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/components/home_card.css') }}">
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/components/home_slide.css') }}">
-  <link rel=stylesheet type=text/css href="{{ url_for('static', filename='css/components/page_heading.css') }}">
-  <script type="text/javascript" src="{{ url_for('static', filename='javascript/home/slideshow.js') }}"></script>
+  {% assets 'stylesheets' %}
+    <link rel="stylesheet" href="{{ ASSET_URL }}">
+  {% endassets %}
 </head>
 
 <html>
@@ -89,5 +80,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 
+    {% assets 'javascripts' %}
+      <script type="text/javascript" src="{{ ASSET_URL }}"></script>
+    {% endassets %}
   </body>
 </html>

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'flask',
+        'Flask-Assets'
     ],
 )


### PR DESCRIPTION
Resolves #2 

Uses [`flask-assets`](https://github.com/miracle2k/flask-assets) to bundle JS and CSS dependencies within the project. Previously we were making a lot of separate requests for assets (esp CSS) and this will cut down on that a lot. Also, assets are minified which will save some bytes.